### PR TITLE
Fix interval membership checks

### DIFF
--- a/src/AMPL/model.jl
+++ b/src/AMPL/model.jl
@@ -318,9 +318,23 @@ function _parse_param!(lex::Lexer, model::JuMPConverter.Model)
             read_token!(lex)
             _read_expression!(lex, (TOKEN_SEMICOLON,))
         elseif t.kind == TOKEN_IDENTIFIER && t.value == "in"
-            # `param name symbolic in SET;` — skip
+            # `param name symbolic in SET;` or an interval check like
+            # qcqp's `param ml integer in [0,n);` / `param sq in (0,1];`.
+            # Half-open intervals mix `[`/`(` with `)`/`]`, so a
+            # balanced expression read would run past the statement —
+            # skip raw tokens up to the next qualifier keyword, `:=`,
+            # or `;` instead. (Not `,`: intervals contain one.)
             read_token!(lex)
-            _read_expression!(lex, (TOKEN_SEMICOLON,))
+            while true
+                nx = peek(lex)
+                if nx.kind in (TOKEN_SEMICOLON, TOKEN_EOF, TOKEN_ASSIGN)
+                    break
+                elseif nx.kind == TOKEN_IDENTIFIER &&
+                       nx.value in ("default", "integer", "binary", "symbolic")
+                    break
+                end
+                read_token!(lex)
+            end
         elseif t.kind == TOKEN_COMMA
             read_token!(lex)
         else
@@ -517,10 +531,9 @@ end
 #
 # Supported syntax matches what real `.mod`/`.dat`s exercise: taxmcp's
 # scalar `fix PL := 1;`, bar-truss-3's `fix{i in m} H[i,'y1','y2'] := 0;`,
-# clnlbeam's numeric indices `fix x[0] := 0.0;`, and optmass's
-# expression value `fix v[1,0] := speed;`. Forms not yet seen — range
-# iter `{i in 1..n}` — would error and can be added when a real
-# `.mod`/`.dat` needs them.
+# clnlbeam's numeric indices `fix x[0] := 0.0;`, optmass's expression
+# value `fix v[1,0] := speed;`, and dtoc1nd's range iter
+# `fix {i in 1..ny} y[1,i] := 0.0;`.
 function _parse_fix!(lex::Lexer)
     iter = nothing
     if peek(lex).kind == TOKEN_LBRACE
@@ -554,8 +567,15 @@ function _parse_fix_iter!(lex::Lexer)
     var = Symbol(expect!(lex, TOKEN_IDENTIFIER).value)
     in_tok = expect!(lex, TOKEN_IDENTIFIER)
     @assert in_tok.value == "in"
-    set = Symbol(expect!(lex, TOKEN_IDENTIFIER).value)
+    # The set is either a bare name (bar-truss-3's `{i in m}`) or an
+    # inline expression (dtoc1nd's `{i in 1..ny}` → `1:ny`).
+    rhs = strip(_read_expression!(lex, (TOKEN_RBRACE,)))
     expect!(lex, TOKEN_RBRACE)
+    set = if occursin(r"^[A-Za-z_][A-Za-z0-9_]*$", rhs)
+        Symbol(rhs)
+    else
+        clean_expression(String(rhs))
+    end
     return JuMPConverter.FixIter(; var, set)
 end
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -54,11 +54,13 @@ end
 # `indices` entries are either a `String` (from AMPL `'foo'`), an
 # `Int` (clnlbeam's `fix x[0]`), or a `Symbol` referring to `iter.var`
 # — that's the index shape real `.dat`s exercise (bar-truss-3).
-# `iter.set` is the set name to iterate over (resolved from the local
-# `build_model` scope at the call site).
+# `iter.set` is the name of the set to iterate over (a `Symbol`,
+# resolved from the local `build_model` scope at the call site) or
+# Julia expression source for an inline range (a `String`, dtoc1nd's
+# `fix {i in 1..ny}` → `1:ny`).
 Base.@kwdef struct FixIter
     var::Symbol
-    set::Symbol
+    set::Union{Symbol,String}
 end
 
 # `value` is a `Float64` for a literal RHS; a non-literal RHS

--- a/test/AMPL/mod_tests.jl
+++ b/test/AMPL/mod_tests.jl
@@ -620,6 +620,28 @@ function test_param_default_expression_becomes_default_expr()
     return
 end
 
+function test_param_interval_check_skipped()
+    # qcqp-style: `param ml integer in [0,n);` and `param sq in (0,1];`
+    # — interval membership checks whose half-open delimiters are
+    # deliberately unbalanced (`[…)`, `(…]`). Like `> 0` checks they
+    # are skipped, and a qualifier after the interval must survive.
+    mod = """
+    param n integer > 0;
+    param ml integer in [0,n);
+    param sq in (0,1];
+    param pf in (0,1] default .2;
+    var x {1..n};
+    minimize obj: sum {i in 1..n} x[i];
+    subject to
+    c {i in 1..ml}: x[i] >= sq;
+    """
+    model = JuMPConverter.AMPL.parse_model(mod)
+    @test model.parameters["ml"].integer
+    @test haskey(model.parameters, "sq")
+    @test model.parameters["pf"].default == 0.2
+    return
+end
+
 function test_param_inline_assign_becomes_default()
     # design-cent-1-style: `param pi := 3.14;` and b-pn2-style
     # `param v1{Y} := 1;` initialize the parameter inline; treat the
@@ -1440,6 +1462,33 @@ function test_model_level_fix_expression_value()
     @test model.fixes[1].value == "speed"
     rendered = sprint(print, model)
     @test contains(rendered, "JuMP.fix(model[:v][1, 0], speed; force = true)")
+    @test Meta.parseall(rendered) isa Expr
+    return
+end
+
+function test_model_level_fix_range_iter()
+    # dtoc2-style: `fix{i in 1..ny} y[1,i] := i/(2*ny);` — the iter set
+    # is an inline range (not a set name) and the fix value is an
+    # expression referencing the iter variable.
+    mod = """
+    param ny integer;
+    var y {1..3, 1..ny};
+    minimize obj: y[1, 1];
+    fix{i in 1..ny} y[1,i] := i/(2*ny);
+    """
+    model = JuMPConverter.AMPL.parse_model(mod)
+    @test length(model.fixes) == 1
+    fx = model.fixes[1]
+    @test fx.iter.var === :i
+    @test fx.iter.set == "1:ny"
+    @test fx.indices == Any[1, :i]
+    @test fx.value == "i / (2 * ny)"
+    rendered = sprint(print, model)
+    @test contains(rendered, "for i in 1:ny")
+    @test contains(
+        rendered,
+        "JuMP.fix(model[:y][1, i], i / (2 * ny); force = true)",
+    )
     @test Meta.parseall(rendered) isa Expr
     return
 end

--- a/test/AMPL/plato_nlp.jl
+++ b/test/AMPL/plato_nlp.jl
@@ -17,19 +17,58 @@ const PLATO_NLP_DIR = joinpath(@__DIR__, "plato_nlp")
 # Files listed in the index whose link is dead (HTTP 404).
 const PLATO_NLP_MISSING = Set(["nql180.mod", "qssp60.mod", "qssp180.mod"])
 
-# Instances whose `read_model` currently fails. These fall into a few
-# categories:
-#
-#   1. Set literals with numeric elements in indexing (`dtoc1nd`, `dtoc2`).
-#   2. Un-parenthesized `if … then … else …` inside constraint expressions
-#      plus `param p integer in (0,1];` interval checks (`qcqp*`).
+# Every instance currently parses (`read_model` succeeds), but for the
+# instances below the rendered `.jl` still contains Julia syntax errors
+# — un-parenthesized `if … then … else` emitted verbatim, negative
+# ranges rendered without spacing (`i in-mo:-1`), AMPL generator forms
+# like `max{i in S} expr`, and similar constructs the emitter doesn't
+# translate yet.
 #
 # Same convention as `dat/macmpec.jl`: a regression on a currently-passing
 # instance errors loudly, and a fix flips the corresponding `@test_broken`
 # into an "unexpected pass" so we know to delete it from this list.
-const PLATO_NLP_BROKEN_PARSE = Set([
+const PLATO_NLP_BROKEN_RENDER = Set([
+    "NARX_CFy",
+    "WM_CFy",
+    "Weyl_m0",
+    "arki0009",
+    "cont_p",
+    "dirichlet120",
+    "dirichlet40",
+    "dirichlet80",
     "dtoc1nd",
-    "dtoc2",
+    "ex1_160",
+    "ex1_320",
+    "ex2_160",
+    "ex2_320",
+    "ex3_160",
+    "ex3_320",
+    "henon120",
+    "henon40",
+    "henon80",
+    "lane_emden120",
+    "lane_emden40",
+    "lane_emden80",
+    "lukvle11",
+    "lukvle12",
+    "lukvle13",
+    "lukvle14",
+    "lukvle15",
+    "lukvle16",
+    "lukvle17",
+    "lukvle18",
+    "lukvle5",
+    "lukvle9",
+    "lukvli11",
+    "lukvli12",
+    "lukvli13",
+    "lukvli14",
+    "lukvli15",
+    "lukvli16",
+    "lukvli17",
+    "lukvli18",
+    "lukvli5",
+    "lukvli9",
     "qcqp1000-1c",
     "qcqp1000-1nc",
     "qcqp1000-2c",
@@ -46,7 +85,17 @@ const PLATO_NLP_BROKEN_PARSE = Set([
     "qcqp750-1nc",
     "qcqp750-2c",
     "qcqp750-2nc",
+    "svanberg",
 ])
+
+# `Meta.parseall` never throws — syntax errors come back embedded as
+# `Expr(:error, …)` / `Expr(:incomplete, …)` nodes, so `isa Expr` alone
+# would accept invalid output.
+function plato_nlp_has_parse_error(x)
+    x isa Expr || return false
+    x.head in (:error, :incomplete) && return true
+    return any(plato_nlp_has_parse_error, x.args)
+end
 
 function plato_nlp_mod_files()
     files = try
@@ -69,14 +118,14 @@ end
         if !isfile(mod_path)
             Downloads.download(PLATO_NLP_URL * mod_file, mod_path)
         end
-        if first(splitext(mod_file)) in PLATO_NLP_BROKEN_PARSE
-            @test_broken JuMPConverter.AMPL.read_model(mod_path) isa
-                         JuMPConverter.Model
+        model = JuMPConverter.AMPL.read_model(mod_path)
+        @test model isa JuMPConverter.Model
+        # The rendered .jl must be syntactically valid Julia.
+        valid = !plato_nlp_has_parse_error(Meta.parseall(sprint(print, model)))
+        if first(splitext(mod_file)) in PLATO_NLP_BROKEN_RENDER
+            @test_broken valid
         else
-            model = JuMPConverter.AMPL.read_model(mod_path)
-            @test model isa JuMPConverter.Model
-            # The rendered .jl must at least be syntactically valid Julia.
-            @test Meta.parseall(sprint(print, model)) isa Expr
+            @test valid
         end
     end
 end


### PR DESCRIPTION
Now JuMPConverter can parse all instances but the generated Julia doesn't always parse