### PR TITLE
Missing keyword argument

### DIFF
--- a/src/AMPL/model.jl
+++ b/src/AMPL/model.jl
@@ -265,6 +265,29 @@ function _boolify_condition(cond::AbstractString)
     return "($c) != 0"
 end
 
+# AMPL parameters declared with `default V` return `V` for any index the
+# `.dat` leaves unset — `param A{J,I} default 0;` populated with `.`
+# entries (hs044-i, siouxfls). JuMP containers throw on a missing key
+# instead, so the generated `build_model` wraps every defaulted indexed
+# parameter in this shim, which falls back to the default on a
+# `KeyError`/`BoundsError`. The underlying container (`SparseAxisArray`,
+# `DenseAxisArray`, `Array`, `Dict`, scalar) is left untouched otherwise.
+struct DefaultArray{D,T}
+    data::D
+    default::T
+end
+
+with_default(data, default) = DefaultArray(data, default)
+
+function Base.getindex(a::DefaultArray, idx...)
+    try
+        return a.data[idx...]
+    catch err
+        (err isa KeyError || err isa BoundsError) && return a.default
+        rethrow()
+    end
+end
+
 # A single axis' set expression as Julia source: brace literals become
 # vectors (ex4_160's `sum{k in {-1,1}}` — Julia's `{}` vector syntax is
 # discontinued), `A..B [by S]` ranges become `A:B` / `A:S:B`, and range

--- a/src/print.jl
+++ b/src/print.jl
@@ -318,6 +318,20 @@ function Base.show(io::IO, model::JuMPConverter.Model)
         join(io, kwargs, ", ")
     end
     println(io, ")")
+    # AMPL parameters with a `default` return it for any index the data
+    # leaves unset; wrap each indexed one so a missing-key access falls
+    # back to the default instead of throwing (the shim is transparent
+    # for a fully-populated container). Done before the variables, whose
+    # bounds may reference such a parameter (`var z >= zl[k], <= zu[k]`).
+    for (kind, name) in model.kwarg_order
+        kind === :param || continue
+        p = model.parameters[name]
+        (isnothing(p.default) || isnothing(p.axes)) && continue
+        println(
+            io,
+            "    $name = JuMPConverter.AMPL.with_default($name, $(_render_number(p.default)))",
+        )
+    end
     println(io, "    model = Model()")
     for variable in values(model.variables)
         println(io, "    ", variable)

--- a/test/AMPL/dat/macmpec.jl
+++ b/test/AMPL/dat/macmpec.jl
@@ -3,14 +3,18 @@ import MacMPEC
 import JuMPConverter
 
 # Instances whose `read_from_file` round-trip currently fails.
-# These fall into three categories:
+# These fall into two categories:
 #
 #   1. `.dat` files that don't actually populate a required `set`/`param`
 #      because the original AMPL script generated the data via a loop
 #      we don't evaluate (`nash1a`–`nash1e` lack `InitPoints`).
-#   2. Models that lean on AMPL's lazy / defaulted indexing semantics
-#      where JuMP requires every accessed key to exist (`siouxfls*`,
-#      `tap-09/15`, `monteiro*`, `water-*`, `hs044-i`, `ralphmod`).
+#   2. Models indexed over a set of tuples (arcs) where a param/variable
+#      is accessed at a tuple outside its domain — `siouxfls*`,
+#      `tap-09/15`, `monteiro*`, `water-*` key by `(i, j)` arcs, and
+#      `ralphmod` accesses a `{state}` variable off its index set. AMPL's
+#      lazy indexing tolerates this; JuMP requires the key to exist.
+#      (The simpler defaulted-scalar-index case, hs044-i, is handled by
+#      `JuMPConverter.AMPL.with_default`.)
 #
 # Wrapping them in `@test_broken` lets `Pkg.test()` stay green: a real
 # regression that newly breaks one of the currently-passing instances
@@ -18,7 +22,6 @@ import JuMPConverter
 # the corresponding `@test_broken` to a "@test passed unexpectedly"
 # failure so we know to delete it.
 const BROKEN_BUILD = Set([
-    "hs044-i",
     "monteiro",
     "monteiroB",
     "nash1a",

--- a/test/AMPL/mod_tests.jl
+++ b/test/AMPL/mod_tests.jl
@@ -1801,6 +1801,30 @@ function test_recursive_param_default_sequential_fill()
     return
 end
 
+function test_defaulted_param_wrapped_with_default()
+    # hs044-i-style `param A{J,I} default 0;` populated sparsely (`.`
+    # entries) — the model accesses every (j,i), so the emitter wraps
+    # the defaulted indexed param so a missing key returns the default.
+    mod = """
+    set I := 1..2;
+    set J := 1..2;
+    param A {J,I} default 0;
+    var x {I} >= 0;
+    minimize obj: sum {i in I} x[i];
+    s.t. c {j in J}: sum {i in I} A[j,i] * x[i] >= 0;
+    """
+    model = JuMPConverter.AMPL.parse_model(mod)
+    rendered = sprint(print, model)
+    @test contains(rendered, "A = JuMPConverter.AMPL.with_default(A, 0)")
+    @test Meta.parseall(rendered) isa Expr
+    # The shim returns the default for a missing key and the value for a
+    # present one.
+    wrapped = JuMPConverter.AMPL.with_default(Dict((1, 1) => 7.0), 0)
+    @test wrapped[1, 1] == 7.0
+    @test wrapped[2, 2] == 0
+    return
+end
+
 end  # module
 
 TestModParsing.runtests()


### PR DESCRIPTION
In `hs044-i`, there are default values for the arguments